### PR TITLE
gem 'sassc-rails'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,4 @@ group :production do
 end
 
 gem 'pry-rails'
+gem 'sassc-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     erubi (1.12.0)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
@@ -202,6 +203,14 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -216,6 +225,7 @@ GEM
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     thor (1.2.2)
+    tilt (2.2.0)
     timeout (0.4.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -257,6 +267,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.0)
   rubocop
+  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails


### PR DESCRIPTION
gem 'sassc-rails'インストールした。
LoadError in RequestsController#index
cannot load such file -- sassc
   ret = require_without_bootsnap(path)